### PR TITLE
Fix the key value for REVOKE_TOKEN_ENDPOINT

### DIFF
--- a/identity-oidc-js/src/constants/endpoints.ts
+++ b/identity-oidc-js/src/constants/endpoints.ts
@@ -36,7 +36,7 @@ export const SERVICE_RESOURCES: ServiceResourcesType = {
 
 export const AUTHORIZATION_ENDPOINT = "authorization_endpoint";
 export const TOKEN_ENDPOINT = "token_endpoint";
-export const REVOKE_TOKEN_ENDPOINT = "revoke_token_endpoint";
+export const REVOKE_TOKEN_ENDPOINT = "revocation_endpoint";
 export const END_SESSION_ENDPOINT = "end_session_endpoint";
 export const JWKS_ENDPOINT = "jwks_uri";
 export const OP_CONFIG_INITIATED = "op_config_initiated";


### PR DESCRIPTION
the `revoke_token_endpoint` is not the key value in the discovery endpoint the actual key value is `revocation_endpoint`
